### PR TITLE
add import Data.Monoid for <>

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,6 +11,7 @@ import System.Directory
 import System.Process (readProcess)
 import System.FilePath
 
+import Data.Monoid((<>))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Options.Applicative


### PR DESCRIPTION
haskdogs will not build without monoid import  for <>
because optparse-applicative-0.13 does no longer export it
