### PR TITLE
Add option for single file and other improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Emacs users would probably want to add -e hasktags option to build Emacs-compati
     haskdogs - Recursive hasktags-based TAGS generator for a Haskell project
 
     Usage: haskdogs [--version] [-d|--dir-list FILE] [-f|--file-list FILE]
-                    [--hasktags-args OPTS] [--stack-args OPTS] [--ghc-pkg-args OPTS]
-                    [--use-stack ARG] [--deps-dir PATH] [--raw] [OPTS]
+                    [-i|--input FILE] [--hasktags-args OPTS] [--stack-args OPTS]
+                    [--ghc-pkg-args OPTS] [--use-stack ARG] [--deps-dir PATH]
+                    [--raw] [OPTS]
 
     Available options:
       -h,--help                Show this help text
@@ -56,6 +57,8 @@ Emacs users would probably want to add -e hasktags option to build Emacs-compati
                                read from stdin)
       -f,--file-list FILE      File containing Haskell sources to process (use '-'
                                to read from stdin)
+      -i,--input FILE          Single Haskell file to process (use '-' to read
+                               Haskell source from stdin)
       --hasktags-args OPTS     Arguments to pass to hasktags. -c -x is the default.
                                Not for raw mode.
       --stack-args OPTS        Arguments to pass to stack
@@ -63,13 +66,12 @@ Emacs users would probably want to add -e hasktags option to build Emacs-compati
       --use-stack ARG          Execute ghc-pkg via stack, arg is ON, OFF or AUTO
                                (the default)
       --deps-dir PATH          Specify the directory PATH to place the dependencies
-                               of the project. Default is [/home/grwlf/.haskdogs]
+                               of the project. Default is [$HOME/.haskdogs]
       --raw                    Don't execute hasktags, print list of files to tag on
                                the STDOUT. The output may be piped into hasktags
                                like this: `haskdogs --raw | hasktags -c -x STDIN'
       OPTS                     More hasktags options, use `--' to pass flags
                                starting with `-'. Not for raw mode.
-
 
 The following error could be caused by (over)strict Haskell policy regarding
 Unicode locale:
@@ -131,3 +133,13 @@ is to run Haskdogs from `nix-shell` as follows:
     (nix-shell) $ haskdogs
 
 
+TIPS
+-----
+
+* create tags for specific package
+
+  ``echo 'import Control.Lens' | haskdogs -i -``
+
+* incremental update
+
+  ``haskdogs -i % --hasktags-args "-x -c -a" | sort -u -o tags tags``

--- a/haskdogs.cabal
+++ b/haskdogs.cabal
@@ -34,12 +34,13 @@ Executable haskdogs
   Hs-source-dirs:       src
   Main-is:              Main.hs
   Build-depends:        base >= 4.8 && < 5
+                      , extra
                       , filepath
                       , bytestring
                       , text
                       , directory
                       , optparse-applicative
-                      , process
+                      , process-extras
                       , containers
                       , hasktags
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -38,6 +38,7 @@ data Opts = Opts {
   , cli_use_stack :: Tristate
   , cli_deps_dir :: FilePath
   , cli_raw_mode :: Bool
+  , cli_verbose        :: Bool
   -- , cli_use_sandbox :: Tristate
   , cli_hasktags_args2 :: [String]
   } deriving(Show)
@@ -94,6 +95,9 @@ optsParser def_deps_dir = Opts
   <*> flag False True (
         long "raw" <>
         help "Don't execute hasktags, print list of files to tag on the STDOUT. The output may be piped into hasktags like this: `haskdogs --raw | hasktags -c -x STDIN'")
+  <*> flag False True (
+        long "verbose" <>
+        help "Output logs")
 
   -- <*> option auto (
   --       long "include-sandbox" <>
@@ -135,8 +139,6 @@ main = do
     getDataDir = do
       createDirectoryIfMissing False cli_deps_dir
       return cli_deps_dir
-
-    cli_verbose = True
 
     vprint a
       | cli_verbose = eprint a


### PR DESCRIPTION
* Add ``--input`` option to support process Haskell source provided on-the-fly, with this option, we can update tags incrementally, or index any package without specifying a source file.
* Add ``--verbose`` option to show logs, it's default to ``False``.
* Refactor some usages of ``String`` to ``Text``, and change ``nub`` to ``nubOrd``, they are supposed to improve performance, although the end result is not affected very much.