### PR TITLE
Read ghc-pkg database concurrently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist-newstyle/
+cabal.project.local

--- a/haskdogs.cabal
+++ b/haskdogs.cabal
@@ -34,15 +34,16 @@ Executable haskdogs
   Hs-source-dirs:       src
   Main-is:              Main.hs
   Build-depends:        base >= 4.8 && < 5
-                      , filepath
-                      , text
+                      , containers
                       , directory
+                      , fast-logger
+                      , filepath
                       , optparse-applicative
                       , process-extras
-                      , containers
-                      , hasktags
+                      , text
+                      , unliftio
 
-  Ghc-options:          -fwarn-tabs
+  Ghc-options:        -fwarn-tabs -threaded -rtsopts -Wall -freverse-errors "-with-rtsopts=-N -xn -I10 -Iw60" -Wunused-packages
 
 Source-repository head
   Type:     git

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -218,9 +218,11 @@ main = do
     -- Finds *hs in dirs, but filter-out Setup.hs
     findSources :: [FilePath] -> IO (Set Text)
     findSources [] = return Set.empty
-    findSources dirs =
-      Set.fromList . filter (not . Text.isSuffixOf "Setup.hs") . Text.lines <$>
-      runp "find" (dirs <> words "-type f -and ( -name *\\.hs -or -name *\\.lhs -or -name *\\.hsc )") ""
+    findSources dirs = do
+      mixedPaths <- map Text.unpack . filter (not . Text.isSuffixOf "Setup.hs") . Text.lines <$>
+        runp "find" (dirs <> words "-type f -and ( -name *\\.hs -or -name *\\.lhs -or -name *\\.hsc )") ""
+      -- use absolute paths because of https://github.com/MarcWeber/hasktags/issues/22
+      Set.fromList . fmap Text.pack <$> traverse canonicalizePath mixedPaths
 
     grepImports :: Text -> Maybe Text
     grepImports line =


### PR DESCRIPTION
haskdogs when executed on a big projects is really slow and can take dozens of minutes to scan packages. The main problem is `ghc-pkg` which uses 2 seconds per each module import to find package name, because I'm using multiple package databases (cabal one and global one):
```bash
haskdogs \
  --use-stack OFF \
  --deps-dir "$XDG_DATA_HOME/haskdogs" \
  --ghc-pkg-args "--package-db $CABAL_DIR/store/ghc-`ghc --numeric-version`/package.db --package-db dist-newstyle/packagedb/ghc-`ghc --numeric-version` --global"
```

This PR changes two things:
1. `ghc-pkg` is executed using `pooledMapConcurrentlyN` , where the number of threads is set to number of cpus * 1.1
1. To avoid mangling log output from multiple threads, `fast-logger` is used