### PR TITLE
Add flake.nix. Update default.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist-newstyle/
+.direnv/
 cabal.project.local
+result

--- a/default.nix
+++ b/default.nix
@@ -1,37 +1,17 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+{
+  nixpkgs ? import <nixpkgs> { },
+  compiler ? "default",
+}:
 
 let
 
   inherit (nixpkgs) pkgs;
 
-  f = { mkDerivation, base, bytestring, containers, directory
-      , filepath, optparse-applicative, process-extras, stdenv, text,
-      cabal-install, hasktags, unliftio, fast-logger
-      }:
-      mkDerivation {
-        pname = "haskdogs";
-        version = "0.4.5";
-        src = ./.;
-        isLibrary = false;
-        isExecutable = true;
-        executableHaskellDepends = [
-          base bytestring containers directory filepath optparse-applicative
-          process-extras text hasktags unliftio fast-logger
-        ];
-        libraryHaskellDepends = [
-          cabal-install
-        ];
-        homepage = "http://github.com/grwlf/haskdogs";
-        description = "Generate tags file for Haskell project and its nearest deps";
-        license = stdenv.lib.licenses.bsd3;
-      };
+  haskellPackages =
+    if compiler == "default" then pkgs.haskellPackages else pkgs.haskell.packages.${compiler};
 
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
-
-  drv = haskellPackages.callPackage f {};
+  drv = haskellPackages.callCabal2nix "haskdogs" ./. { };
 
 in
 
-  if pkgs.lib.inNixShell then drv.env else drv
+if pkgs.lib.inNixShell then drv.env else drv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "Generate tags file for Haskell project and its nearest deps";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+      pkgsFor = system: import nixpkgs { inherit system; };
+      drvFor = system: import ./default.nix { nixpkgs = pkgsFor system; };
+    in
+    {
+      packages = forAllSystems (system: {
+        default = drvFor system;
+      });
+      devShells = forAllSystems (system: {
+        default = (drvFor system).env;
+      });
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt);
+    };
+}


### PR DESCRIPTION
Adds `.envrc`, `flake.nix`. Reformats all files with `nixfmt`. Updates `default.nix` to use cabal2nix.